### PR TITLE
Add rumdl for Markdown and MDX linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 *.tmp
 .vscode/
 test.py
+.rumdl_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,13 @@ repos:
     - --preserve-quotes
     - --indent=2
 
+- repo: https://github.com/rvben/rumdl-pre-commit
+  rev: v0.2.41
+  hooks:
+  - id: rumdl
+    types: [text]
+    files: '\.mdx?$'
+
 - repo: local
   hooks:
   - id: black

--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -1,0 +1,24 @@
+# rumdl configuration - https://github.com/rvben/rumdl
+# Markdown/MDX linting for the docs. Correctness rules stay on (broken links,
+# code-fence languages, list and heading structure); a few purely-stylistic or
+# doc-specific rules are turned off below.
+
+[global]
+disable = [
+  # Line length: docs contain long tables, URLs and code samples that are not
+  # hard-wrapped, so an 80-column limit is noise here.
+  "MD013",
+  # Multiple top-level headings: pages take their title from front matter and
+  # legitimately use several top-level sections in the body.
+  "MD025",
+  # Spaces inside emphasis markers: false-positives on adjacent emphasis spans
+  # such as *"a"*, *"b"*, where the closing and opening markers are misread.
+  "MD037",
+]
+
+# Validate Mintlify-style root-relative internal links (for example
+# /workspace/teams) against the docs tree, so a broken internal link is caught
+# rather than ignored. mint.json sits at the repo root, so the root is ".".
+[MD057]
+absolute-links = "relative_to_roots"
+roots = ["."]

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ### Build the docker image
 
-```
+```bash
 docker build -t docs:latest -f Dockerfile .
 ```
 
 ### Run the docker image
 
-```
+```bash
 docker run -v .:/docs -p 3000:3000 docs:latest
 ```
 
@@ -22,7 +22,7 @@ The `mintlify dev` command downloads the mintlify framework everytime we create 
 
 In order to save time, I'd suggest just restarting the previously existing container rather than creating a new one, the docker image only really contains the `node:bookworm` docker image and the installation of `mintlify`.
 
-```
+```bash
 docker restart <container-id>
 ```
 

--- a/workspace/connecting.mdx
+++ b/workspace/connecting.mdx
@@ -31,6 +31,7 @@ open it from several places — they all lead to the same dialog:
     | Calendar | Optional | Optional |
     | Contacts | Optional | Optional |
     | Tasks | Optional | Optional |
+
   </Step>
   <Step title="Sign in and approve">
     Click **Connect**. A new tab opens with the familiar Google or Microsoft


### PR DESCRIPTION
Follows up on the thread with Dan about Markdown linting. Right now the repo
lints Python, YAML and secrets, but Markdown and MDX only get
trailing-whitespace and end-of-file-fixer. This wires in rumdl
(https://github.com/rvben/rumdl, MIT, Rust) as one pre-commit stanza.

## What this does

- Adds the `rumdl` hook to `.pre-commit-config.yaml`, pinned to v0.2.41,
  matching both `.md` and `.mdx` (86 files).
- Adds `.rumdl.toml` that keeps the correctness rules on. It configures MD057
  to validate Mintlify-style root-relative internal links (for example
  `/workspace/teams`) against the docs tree, so a broken internal link fails
  the hook instead of being ignored. All 263 such links currently resolve.
- Disables three rules unsuited to a docs set:
  - `MD013` line length: docs have long tables, URLs and code samples that are
    not hard-wrapped.
  - `MD025` multiple top-level headings: pages take their title from front
    matter and use several body sections.
  - `MD037` spaces inside emphasis: false positive on adjacent emphasis spans
    such as `*"a"*, *"b"*`.
- Fixes the issues rumdl flagged so the hook is green from the first run:
  - `README.md`: three shell code blocks now tagged `bash` (MD040).
  - `workspace/connecting.mdx`: blank line after a table (MD058).
- Gitignores `.rumdl_cache/`.

## Verification

- `pre-commit run rumdl --all-files` passes on all 86 files.
- Confirmed the hook lints `.mdx`, not just `.md`, and that MD057 flags a broken
  root-relative link while leaving valid ones alone.
- No CI impact: tests.yml runs black and pytest only; this is a local pre-commit gate.

Targeting `staging` per the staging-first promotion flow.
